### PR TITLE
Fix filter references to sheet types

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: a11ytables
 Title: Create Spreadsheet Publications Following GSS Best Practice
-Version: 0.0.0.9005
+Version: 0.0.0.9006
 Authors@R: 
     person(given = "Matt",
            family = "Dray",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# a11ytables 0.0.0.9006
+
+* HOTFIX: fixed a problem where the `tab_title` was being used to filter when it should have been `sheet_type`
+
 # a11ytables 0.0.0.9005
 
 * BREAKING CHANGE: the user-supplied table for the cover sheet should now be supplied as a tidy two-column data.frame with a row per subsection, with columns for the `subsection_title` and `subsection_body` (suggesetd names)

--- a/R/tables.R
+++ b/R/tables.R
@@ -32,7 +32,7 @@ create_a11y_wb <- function(content) {
   wb <- .add_contents(wb, content)
 
   # There won't always be a notes tab
-  if (any(content$tab_title %in% "notes")) {
+  if (any(content$sheet_type %in% "notes")) {
     wb <- .add_notes(wb, content)
   }
 

--- a/R/utils-style.R
+++ b/R/utils-style.R
@@ -53,8 +53,8 @@
 
 .style_cover <- function(wb, content, style_ref) {
 
-  tab_name <- "cover"
-  table <- content[content$tab_title == "cover", "table"][[1]]
+  tab_name <- content[content$sheet_type == "cover", "tab_title"][[1]]
+  table <- content[content$sheet_type == "cover", "table"][[1]]
   table_height <- nrow(table)
 
   # The cover column is SET-WIDTH and WRAPPED
@@ -165,8 +165,8 @@
 
 .style_contents <- function(wb, content, style_ref) {
 
-  tab_name <- "contents"
-  table <- content[content$tab_title == "contents", "table"][[1]]
+  tab_name <- content[content$sheet_type == "contents", "tab_title"][[1]]
+  table <- content[content$sheet_type == "contents", "table"][[1]]
   table_height <- nrow(table)
   table_width <- ncol(table)
 
@@ -204,8 +204,8 @@
 
 .style_notes <- function(wb, content, style_ref) {
 
-  tab_name <- "notes"
-  table <- content[content$tab_title == "notes", "table"][[1]]
+  tab_name <- content[content$sheet_type == "notes", "tab_title"][[1]]
+  table <- content[content$sheet_type == "notes", "table"][[1]]
   table_height <- nrow(table)
   table_width <- ncol(table)
 

--- a/R/utils-tables.R
+++ b/R/utils-tables.R
@@ -65,6 +65,7 @@
 .insert_prelim_a11y <- function(wb, content, tab_title) {
 
   table_count <- nrow(content[content$tab_title == tab_title, ])
+
   has_notes <- any(
     grepl(
       "[note [0-9]{1,3}]",
@@ -100,22 +101,23 @@
 
 .insert_table <- function(wb, content, table_name, subtable_num = NULL) {
 
-  table <- content[content$table_name == table_name, "table"][[1]]
+  table <- content[content$table_name == table_name, ][["table"]][[1]]
+  sheet_type <- content[content$table_name == table_name, "sheet_type"][[1]]
   tab_title <- content[content$table_name == table_name, "tab_title"][[1]]
 
-  if (tab_title == "cover") {
+  if (sheet_type == "cover") {
     start_row <- 2
   }
 
-  if (tab_title %in% c("contents", "notes")) {
+  if (sheet_type %in% c("contents", "notes")) {
     start_row <- 3
   }
 
-  if (!tab_title %in% c("cover", "contents", "notes")) {
+  if (!sheet_type %in% c("cover", "contents", "notes")) {
     start_row <- 4
   }
 
-  if (tab_title == "cover") {
+  if (sheet_type == "cover") {
 
     table <- data.frame(cover_content = as.vector(t(table)))
 
@@ -130,7 +132,7 @@
 
   }
 
-  if (tab_title != "cover") {
+  if (sheet_type != "cover") {
 
     openxlsx::writeDataTable(
       wb = wb,


### PR DESCRIPTION
Column `tab_title` in the input was being referenced instead of `sheet_type`, which wasn't detected when working with the `lfs_tables` example dataset because the strings are the same in both of these columns.