### PR TITLE
Align numeric columns in tables

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: a11ytables
 Title: Create Spreadsheet Publications Following GSS Best Practice
-Version: 0.0.0.9007
+Version: 0.0.0.9008
 Authors@R: 
     person(given = "Matt",
            family = "Dray",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,12 @@
+# a11ytables 0.0.0.9008
+
+* Ensured numeric columns (even if they contain a string like '[c]' to indicate a suppressed value) are right-aligned (#32)
+* Isolated out .insert_*() functions for table count and note presence from `.insert_prelim_a11y()`, for clarity
+
 # a11ytables 0.0.0.9007
 
 * BREAKING CHANGE: subtable arguments removed because they're not being used for now and are confusing
-* Added the first draft vignettes on how to create an a11ytable and an accessibility guidance checklist (see #22)
+* Added the first draft vignettes on how to create an a11ytable and an accessibility guidance checklist (#22)
 
 # a11ytables 0.0.0.9006
 
@@ -9,7 +14,7 @@
 
 # a11ytables 0.0.0.9005
 
-* BREAKING CHANGE: the user-supplied table for the cover sheet should now be supplied as a tidy two-column data.frame with a row per subsection, with columns for the `subsection_title` and `subsection_body` (suggesetd names)
+* BREAKING CHANGE: the user-supplied table for the cover sheet should now be supplied as a tidy two-column data.frame with a row per subsection, with columns for the `subsection_title` and `subsection_body` (suggestd names)
 * The `lfs_tables` and `lfs_subtables` example datasets have been updated accordingly; for an example see `lfs_tables[lfs_tables$sheet_type == "cover", "table"][[1]]`
 
 # a11ytables 0.0.0.9004

--- a/R/class.R
+++ b/R/class.R
@@ -1,40 +1,46 @@
 
 #' Create An a11ytable-class Object
 #'
-#' Create an object containing all the input data and supporting information
-#' for your publication, which will be used to populate a workbook.
+#' Create a new a11ytable-class object, which is a data.frame that contains all
+#' the information needed in your publication. In turn, this will be used to
+#' populate an 'openxlsx' Workbook-class object with the function
+#' \code{\link{create_a11y_wb}}.
 #'
-#' @param tab_titles Required character vector, one value per sheet. The text
-#'     that will appear on the tab interface of the when opened in spreadsheet
-#'     software. Provide table sheets as numbers.
-#' @param sheet_types Required character vector, one value per sheet. Meta
-#'     sheets (i.e. those that don't contain publication tables) should be
-#'     'contents', 'cover' or 'notes'; publication tables are type 'tables'.
-#' @param sheet_titles Required character vector, one value per sheet. The main
-#'     title of the sheet. Will appear in large text in cell A1 (top-left)
-#'     corner of each sheet.
-#' @param sources Optional character vector, one value per sheet (NA is valid).
-#'     The origin of the data for a given sheet.
-#' @param table_names Required character vector, one value per sheet. A name to
+#' @param tab_titles Required character vector, one value per sheet to be
+#'     created. Each title will appear on each tab of the final spreadsheet
+#'     output. Keep brief.
+#' @param sheet_types Required character vector, one value per sheet to be
+#'     created. Sheets that don't contain publication tables ('meta' sheets)
+#'     should be of type 'contents', 'cover' or 'notes'. Sheets that contain
+#'     statistical tables of data are type 'tables'.
+#' @param sheet_titles Required character vector, one value per sheet to be
+#'     created. The main title of the sheet, which will appear in cell A1
+#'     (top-left corner) of each sheet.
+#' @param sources Optional character vector, one value per sheet to be created.
+#'     The origin of the data for a given sheet. Supply as \code{NA_character_}
+#'     if empty.
+#' @param table_names Required character vector, one value per table to be
+#'     created (i.e. one per sheet). A short, descriptive, identifying name to
 #'     give the 'named range' of cells that compose the table in the final
-#'     spreadsheet output. Makes sheet navigation easier.
+#'     spreadsheet output. Makes sheet navigation more accessible.
 #' @param tables Required list of data.frames, one per sheet. See details.
 #'
 #' @details Formats for data.frames in the 'tables' argument, depending on the
-#'     sheet type:
+#'     sheet type.
 #' \itemize{
-#'     \item cover: one column with a pair of rows for each point of information
-#'         (a section with contact details should have a row for the title of that
-#'         section, like 'Contact details' and one row containing the information;
-#'         use line breaks to separate information onto different lines, like a
-#'         telephone number and email address in this example)
-#'     \item contents: one row per sheet, five columns suggested ('Worksheet
-#'         number', 'Worksheet title', 'Data of first publication', 'Date of
-#'         next publication', 'Source')
-#'     \item notes: one row per note, two columns suggested ('Note number',
-#'         'Note text')
-#'     \item tables: a tidy, rectangular data.frame containing the data to be
-#'         published
+#'     \item Sheet type 'cover': one row per subsection, with columns for
+#'         'Subsection title' and 'Subsection text'. For example, a section with
+#'         contact details might have 'Contact details' as the subsection title
+#'         and a telephone number and email address in the body-text column. Use
+#'         linebreaks (i.e. '\n') to put multiple rows in the same body text.
+#'         Don't break information into separate spreadsheet rows if they belong
+#'         in the same subsection).
+#'     \item Sheet type 'contents': one row per sheet, two columns suggested at
+#'         least ('Tab title' and 'Worksheet title').
+#'     \item Sheet type 'notes': one row per note, two columns suggested ('Note
+#'         number', 'Note text').
+#'     \item Sheet type 'tables': a tidy, rectangular data.frame containing the
+#'         data to be published.
 #' }
 #'
 #' @return An a11ytables-class object.
@@ -42,12 +48,12 @@
 #' @examples
 #' \dontrun{
 #' x <- new_a11ytable(
-#'     tab_titles      = lfs_tables$tab_title,
-#'     sheet_types     = lfs_tables$sheet_type,
-#'     sheet_titles    = lfs_tables$sheet_title,
-#'     sources         = lfs_tables$source,
-#'     table_names     = lfs_tables$table_name,
-#      tables          = lfs_tables$table
+#'     tab_titles   = lfs_tables$tab_title,
+#'     sheet_types  = lfs_tables$sheet_type,
+#'     sheet_titles = lfs_tables$sheet_title,
+#'     sources      = lfs_tables$source,
+#'     table_names  = lfs_tables$table_name,
+#      tables       = lfs_tables$table
 #' )
 #' is_a11ytable(x)
 #' }

--- a/R/class.R
+++ b/R/class.R
@@ -32,7 +32,7 @@
 #'         'Subsection title' and 'Subsection text'. For example, a section with
 #'         contact details might have 'Contact details' as the subsection title
 #'         and a telephone number and email address in the body-text column. Use
-#'         linebreaks (i.e. '\n') to put multiple rows in the same body text.
+#'         linebreaks (i.e. '\\n') to put multiple rows in the same body text.
 #'         Don't break information into separate spreadsheet rows if they belong
 #'         in the same subsection).
 #'     \item Sheet type 'contents': one row per sheet, two columns suggested at

--- a/R/utils-style.R
+++ b/R/utils-style.R
@@ -117,7 +117,7 @@
   table_width <- ncol(table)
 
   if (sheet_type %in% c("cover", "contents", "notes")) table_header_row <- 3
-  if (sheet_type == "tables") table_header_row <- 4
+  if (sheet_type == "tables") table_header_row <- 5
 
   # Table data columns are SET-WIDTH, WRAPPED and RIGHT ALIGNED
 

--- a/R/utils-style.R
+++ b/R/utils-style.R
@@ -113,11 +113,35 @@
   table <- content[content$table_name == table_name, "table"][[1]]
   tab_title <- content[content$table_name == table_name, "tab_title"][[1]]
   sheet_type <- content[content$table_name == table_name, "sheet_type"][[1]]
-  table_height <- nrow(table)
-  table_width <- ncol(table)
 
-  if (sheet_type %in% c("cover", "contents", "notes")) table_header_row <- 3
-  if (sheet_type == "tables") table_header_row <- 5
+  table_height <- nrow(table)
+  table_width  <- ncol(table)
+
+  # Some columns may contain numbers but have suppression text in them, e.g.
+  # '[c]', which makes the column character class. Find the likely numeric cols.
+  suppressWarnings(  # coercion to numeric may trigger a warning
+    likely_num_cols <-
+      names(  # return names of columns that a remost likely numeric
+        Filter(
+          isTRUE,  # isolate the columns that are likely numeric
+          lapply(
+            lapply(table, as.numeric),  # coerce cols to numeric
+            function(x) any(!is.na(x))  # at least one number after coercion?
+          )
+        )
+      )
+  )
+
+  # Get the index of columns that are likely, so styles can be applied
+  num_cols_index <- which(names(table) %in% likely_num_cols)
+
+  if (sheet_type %in% c("cover", "contents", "notes")) {
+    table_header_row <- 3
+  }
+
+  if (sheet_type == "tables") {
+    table_header_row <- 5
+  }
 
   # Table data columns are SET-WIDTH, WRAPPED and RIGHT ALIGNED
 
@@ -141,7 +165,7 @@
     wb = wb,
     sheet = tab_title,
     rows = seq(table_header_row, table_header_row + table_height),
-    cols = seq(table_width)[-1],  # assumes first col is row labels
+    cols = num_cols_index,
     gridExpand = TRUE,
     style = style_ref$ralign,
     stack = TRUE
@@ -157,7 +181,6 @@
     style = style_ref$bold,
     stack = TRUE
   )
-
 
   return(wb)
 

--- a/R/utils-tables.R
+++ b/R/utils-tables.R
@@ -18,7 +18,7 @@
 }
 
 
-# Construct sheets --------------------------------------------------------
+# Insert sheet elements ---------------------------------------------------
 
 
 .insert_title <- function(wb, content, tab_title) {
@@ -26,7 +26,7 @@
   sheet_title <- content[content$tab_title == tab_title, "sheet_title"][[1]]
 
   if (content[content$tab_title == tab_title, "sheet_type"][[1]] == "tables") {
-    sheet_title <- paste0("Worksheet ", tab_title, ": ", sheet_title)
+    sheet_title <- paste0(tab_title, ": ", sheet_title)
   }
 
   openxlsx::writeData(
@@ -42,19 +42,18 @@
 
 }
 
-.insert_source <- function(wb, content, tab_title) {
+.insert_table_count <- function(wb, content, tab_title) {
 
-  text <- paste(
-    "Source:",
-    content[content$tab_title == tab_title, "source"][[1]]
-  )
+  table_count <- nrow(content[content$tab_title == tab_title, ])
+
+  text <- paste("This worksheet contains", table_count, "table.")
 
   openxlsx::writeData(
     wb = wb,
     sheet = tab_title,
     x = text,
     startCol = 1,
-    startRow = 3,
+    startRow = 2,  # table count will always be the second row
     colNames = TRUE
   )
 
@@ -62,26 +61,55 @@
 
 }
 
-.insert_prelim_a11y <- function(wb, content, tab_title) {
+.check_for_notes <- function(content, tab_title) {
 
-  table_count <- nrow(content[content$tab_title == tab_title, ])
+  table_names <-
+    names(content[content$tab_title == tab_title, "table"][[1]][[1]])
 
-  has_notes <- any(
-    grepl(
-      "[note [0-9]{1,3}]",
-      names(content[content$tab_title == tab_title, "table"][[1]][[1]])
-    )
-  )
+  has_header_notes <- any(grepl("[[0-9]{1,3}]", table_names))
+  has_notes_column <- any(table_names %in% "Notes")
 
-  text <- paste("This worksheet contains", table_count, "table.")
+  has_header_notes | has_notes_column
+
+}
+
+.insert_notes_statement <- function(wb, content, tab_title) {
+
+  has_notes <- .check_for_notes(content, tab_title)
 
   if (has_notes) {
+    text <-
+      "This table contains notes, which can be found in the Notes worksheet."
+  }
 
-    text <- paste(
-      text,
-      "Some cells refer to notes which can be found on the notes worksheet."
-    )
+  if (!has_notes) {
+    text <- "There are no notes in this table."
+  }
 
+openxlsx::writeData(
+  wb = wb,
+  sheet = tab_title,
+  x = text,
+  startCol = 1,
+  startRow = 3,  # TODO: can we make this dynamic depending on whether source exists?
+  colNames = TRUE
+)
+
+return(wb)
+
+}
+
+.insert_source <- function(wb, content, tab_title) {
+
+  source_text <- content[content$tab_title == tab_title, "source"][[1]]
+  has_source_text <- ifelse(!is.na(source_text), TRUE, FALSE)
+
+  if (has_source_text) {
+    text <- paste("Source:", source_text)
+  }
+
+  if (!has_source_text) {
+    text <- "No data source has been provided for this table."
   }
 
   openxlsx::writeData(
@@ -89,7 +117,7 @@
     sheet = tab_title,
     x = text,
     startCol = 1,
-    startRow = 2,
+    startRow = 4,  # TODO: can we make this dynamic depending on whether notes exists?
     colNames = TRUE
   )
 
@@ -104,43 +132,6 @@
   tab_title <- content[content$table_name == table_name, "tab_title"][[1]]
   source <- content[content$table_name == table_name, ][["source"]][[1]]
 
-  has_notes <- any(
-    grepl(
-      "[note [0-9]{1,3}]",
-      names(content[content$tab_title == tab_title, "table"][[1]][[1]])
-    )
-  )
-
-  has_source <- ifelse(is.na(source), FALSE, TRUE)
-
-  if (sheet_type == "cover") {
-    start_row <- 2
-  }
-
-  if (sheet_type %in% c("contents", "notes")) {
-    start_row <- 3
-  }
-
-  if (!sheet_type %in% c("cover", "contents", "notes")) {
-
-    if(has_notes & has_source) {
-      start_row <- 5
-    }
-
-    if(has_notes & !has_source) {
-      start_row <- 4
-    }
-
-    if(!has_notes & has_source) {
-      start_row <- 4
-    }
-
-    if(!has_notes & !has_source) {
-      start_row <- 3
-    }
-
-  }
-
   if (sheet_type == "cover") {
 
     table <- data.frame(cover_content = as.vector(t(table)))
@@ -150,13 +141,21 @@
       sheet = tab_title,
       x = table,
       startCol = 1,
-      startRow = start_row,
+      startRow = 2,
       colNames = FALSE  # because cover df uses dummy column headers
     )
 
   }
 
   if (sheet_type != "cover") {
+
+    if (sheet_type %in% c("contents", "notes")) {
+      start_row <- 3
+    }
+
+    if (sheet_type == "tables") {
+      start_row <- 5
+    }
 
     openxlsx::writeDataTable(
       wb = wb,
@@ -178,8 +177,7 @@
 }
 
 
-# Add sheets --------------------------------------------------------------
-
+# Add sheets to workbook --------------------------------------------------
 
 
 .add_tabs <- function(wb, content) {
@@ -223,7 +221,7 @@
 
 
   .insert_title(wb, content, tab_title)
-  .insert_prelim_a11y(wb, content, tab_title)
+  .insert_table_count(wb, content, tab_title)
   .insert_table(wb, content, table_name)
 
   styles <- .style_create()
@@ -245,7 +243,7 @@
   table_name <- content[content$sheet_type == "notes", "table_name"][[1]]
 
   .insert_title(wb, content, tab_title)
-  .insert_prelim_a11y(wb, content, tab_title)
+  .insert_table_count(wb, content, tab_title)
   .insert_table(wb, content, table_name)
 
   styles <- .style_create()
@@ -265,8 +263,9 @@
   tab_title <- content[content$table_name == table_name, "tab_title"][[1]]
 
   .insert_title(wb, content, tab_title)
-  .insert_prelim_a11y(wb, content, tab_title)
+  .insert_table_count(wb, content, tab_title)
   .insert_source(wb, content, tab_title)
+  .insert_notes_statement(wb, content, tab_title)
   .insert_table(wb, content, table_name)
 
   styles <- .style_create()

--- a/R/utils-tables.R
+++ b/R/utils-tables.R
@@ -69,9 +69,7 @@
   has_notes <- any(
     grepl(
       "[note [0-9]{1,3}]",
-      names(
-        content[content$tab_title == tab_title, "table"][[1]][[1]]
-      )
+      names(content[content$tab_title == tab_title, "table"][[1]][[1]])
     )
   )
 
@@ -104,6 +102,16 @@
   table <- content[content$table_name == table_name, ][["table"]][[1]]
   sheet_type <- content[content$table_name == table_name, "sheet_type"][[1]]
   tab_title <- content[content$table_name == table_name, "tab_title"][[1]]
+  source <- content[content$table_name == table_name, ][["source"]][[1]]
+
+  has_notes <- any(
+    grepl(
+      "[note [0-9]{1,3}]",
+      names(content[content$tab_title == tab_title, "table"][[1]][[1]])
+    )
+  )
+
+  has_source <- ifelse(is.na(source), FALSE, TRUE)
 
   if (sheet_type == "cover") {
     start_row <- 2
@@ -114,7 +122,23 @@
   }
 
   if (!sheet_type %in% c("cover", "contents", "notes")) {
-    start_row <- 4
+
+    if(has_notes & has_source) {
+      start_row <- 5
+    }
+
+    if(has_notes & !has_source) {
+      start_row <- 4
+    }
+
+    if(!has_notes & has_source) {
+      start_row <- 4
+    }
+
+    if(!has_notes & !has_source) {
+      start_row <- 3
+    }
+
   }
 
   if (sheet_type == "cover") {
@@ -127,7 +151,7 @@
       x = table,
       startCol = 1,
       startRow = start_row,
-      colNames = FALSE  # assumes cover df uses a dummy header
+      colNames = FALSE  # because cover df uses dummy column headers
     )
 
   }

--- a/man/new_a11ytable.Rd
+++ b/man/new_a11ytable.Rd
@@ -14,24 +14,27 @@ new_a11ytable(
 )
 }
 \arguments{
-\item{tab_titles}{Required character vector, one value per sheet. The text
-that will appear on the tab interface of the when opened in spreadsheet
-software. Provide table sheets as numbers.}
+\item{tab_titles}{Required character vector, one value per sheet to be
+created. Each title will appear on each tab of the final spreadsheet
+output. Keep brief.}
 
-\item{sheet_types}{Required character vector, one value per sheet. Meta
-sheets (i.e. those that don't contain publication tables) should be
-'contents', 'cover' or 'notes'; publication tables are type 'tables'.}
+\item{sheet_types}{Required character vector, one value per sheet to be
+created. Sheets that don't contain publication tables ('meta' sheets)
+should be of type 'contents', 'cover' or 'notes'. Sheets that contain
+statistical tables of data are type 'tables'.}
 
-\item{sheet_titles}{Required character vector, one value per sheet. The main
-title of the sheet. Will appear in large text in cell A1 (top-left)
-corner of each sheet.}
+\item{sheet_titles}{Required character vector, one value per sheet to be
+created. The main title of the sheet, which will appear in cell A1
+(top-left corner) of each sheet.}
 
-\item{sources}{Optional character vector, one value per sheet (NA is valid).
-The origin of the data for a given sheet.}
+\item{sources}{Optional character vector, one value per sheet to be created.
+The origin of the data for a given sheet. Supply as \code{NA_character_}
+if empty.}
 
-\item{table_names}{Required character vector, one value per sheet. A name to
+\item{table_names}{Required character vector, one value per table to be
+created (i.e. one per sheet). A short, descriptive, identifying name to
 give the 'named range' of cells that compose the table in the final
-spreadsheet output. Makes sheet navigation easier.}
+spreadsheet output. Makes sheet navigation more accessible.}
 
 \item{tables}{Required list of data.frames, one per sheet. See details.}
 }
@@ -39,35 +42,38 @@ spreadsheet output. Makes sheet navigation easier.}
 An a11ytables-class object.
 }
 \description{
-Create an object containing all the input data and supporting information
-for your publication, which will be used to populate a workbook.
+Create a new a11ytable-class object, which is a data.frame that contains all
+the information needed in your publication. In turn, this will be used to
+populate an 'openxlsx' Workbook-class object with the function
+\code{\link{create_a11y_wb}}.
 }
 \details{
 Formats for data.frames in the 'tables' argument, depending on the
-sheet type:
+sheet type.
 \itemize{
-\item cover: one column with a pair of rows for each point of information
-(a section with contact details should have a row for the title of that
-section, like 'Contact details' and one row containing the information;
-use line breaks to separate information onto different lines, like a
-telephone number and email address in this example)
-\item contents: one row per sheet, five columns suggested ('Worksheet
-number', 'Worksheet title', 'Data of first publication', 'Date of
-next publication', 'Source')
-\item notes: one row per note, two columns suggested ('Note number',
-'Note text')
-\item tables: a tidy, rectangular data.frame containing the data to be
-published
+\item Sheet type 'cover': one row per subsection, with columns for
+'Subsection title' and 'Subsection text'. For example, a section with
+contact details might have 'Contact details' as the subsection title
+and a telephone number and email address in the body-text column. Use
+linebreaks (i.e. '\n') to put multiple rows in the same body text.
+Don't break information into separate spreadsheet rows if they belong
+in the same subsection).
+\item Sheet type 'contents': one row per sheet, two columns suggested at
+least ('Tab title' and 'Worksheet title').
+\item Sheet type 'notes': one row per note, two columns suggested ('Note
+number', 'Note text').
+\item Sheet type 'tables': a tidy, rectangular data.frame containing the
+data to be published.
 }
 }
 \examples{
 \dontrun{
 x <- new_a11ytable(
-    tab_titles      = lfs_tables$tab_title,
-    sheet_types     = lfs_tables$sheet_type,
-    sheet_titles    = lfs_tables$sheet_title,
-    sources         = lfs_tables$source,
-    table_names     = lfs_tables$table_name,
+    tab_titles   = lfs_tables$tab_title,
+    sheet_types  = lfs_tables$sheet_type,
+    sheet_titles = lfs_tables$sheet_title,
+    sources      = lfs_tables$source,
+    table_names  = lfs_tables$table_name,
 )
 is_a11ytable(x)
 }

--- a/man/new_a11ytable.Rd
+++ b/man/new_a11ytable.Rd
@@ -55,7 +55,7 @@ sheet type.
 'Subsection title' and 'Subsection text'. For example, a section with
 contact details might have 'Contact details' as the subsection title
 and a telephone number and email address in the body-text column. Use
-linebreaks (i.e. '\n') to put multiple rows in the same body text.
+linebreaks (i.e. '\\n') to put multiple rows in the same body text.
 Don't break information into separate spreadsheet rows if they belong
 in the same subsection).
 \item Sheet type 'contents': one row per sheet, two columns suggested at


### PR DESCRIPTION
* Try to right-align numeric columns, including what are perceived to be numeric despite having character class (e.g. they contain a suppression note like , '[c]')
* Ensure four elements shown in tables sheets (title, statements on table count, notes count and data source)
* Update docs