### PR TITLE
Update to CO pkgdown styling

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,4 +1,23 @@
 url: https://co-analysis.github.io/a11ytables/
+
+template:
+  bootstrap: 5
+  bslib:
+    bg: "#ffffff"
+    fg: "#4d4e53"
+    primary: "#005abb"
+    code_font: {google: "Fira Code"}
+
+navbar:
+  bg: primary
+
+footer:
+  structure:
+    left: legal
+    right: built_with
+  components:
+    legal: © Crown Copyright, 2002, Cabinet Office
+
 reference:
 - title: "a11ytables"
   desc: "Create, coerce and inspect a11ytable-class objects"

--- a/pkgdown/extra.css
+++ b/pkgdown/extra.css
@@ -1,0 +1,56 @@
+@import url('https://fonts.googleapis.com/css2?family=Heebo:wght@100;300;400;500;700;800;900&display=swap');
+
+body {
+  font-family: "Heebo", "HelveticaNeue-Light", "Helvetica Neue Light",
+    "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-weight: 300 !important;
+}
+
+strong {
+  font-weight: 500 !important;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  margin-top: 1rem;
+  font-weight: 500 !important;
+}
+
+svg text {
+  font-family: "Heebo", "HelveticaNeue-Light", "Helvetica Neue Light",
+    "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+
+.footnotes {
+  font-size: 10pt;
+}
+
+.navbar-dark input[type="search"] {
+  background-color: #ffffff;
+  color: var(--co-primary-grey);
+  font-weight: 300;
+}
+
+.navbar-dark .navbar-nav .nav-link {
+  color: rgba(255,255,255,0.85)
+}
+
+.search-details {
+  font-weight: 500;
+}
+
+.text-muted {
+  color: #9dd2ef !important;
+}
+
+.dropdown-menu .dropdown-item {
+  font-weight: 300 !important;
+}
+
+.dropdown-menu .dropdown-header {
+  color: var(--co-primary-blue);
+  font-weight: 500 !important;
+}
+
+dt {
+  font-weight: 500;
+}


### PR DESCRIPTION
Update styling of pkgdown documentation to that used in [{deckhand}](https://github.com/co-analysis/deckhand/).

![preview of new documentation styling](https://user-images.githubusercontent.com/35345053/165534239-24955e71-3a8e-426c-96e4-d17796094d75.png)

