### PR TITLE
Correct documentation issues, update GitHub Actions

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -20,13 +20,13 @@ This outlines how to propose a change to {a11ytables}.
 * Install all development dependencies with `devtools::install_dev_deps()`, and then make sure the package passes R CMD check by running `devtools::check()`. If R CMD check doesn't pass cleanly, it's a good idea to ask for help before continuing. 
 * Create a Git branch for your pull request (PR). The new branch name should start with your initials, e.g. 'xy-fix-bug'.
 * Make your changes, commit to git, and then create a PR. The title of your PR should briefly describe the change. The body of your PR should contain `Fixes #issue-number`.
-*  For user-facing changes, add a bullet to the top of `NEWS.md` (i.e. just below the first header).
+* For user-facing changes, add a bullet to the top of `NEWS.md` (i.e. just below the first header).
 
 ### Code style
 
-* New code should follow the tidyverse [style guide](https://style.tidyverse.org). You can use the [styler](https://CRAN.R-project.org/package=styler) package to apply these styles, but please don't restyle code that has nothing to do with your PR.  
-*  We use [roxygen2](https://cran.r-project.org/package=roxygen2) for documentation.
-*  We use [testthat](https://cran.r-project.org/package=testthat) for unit tests. Contributions with test cases included are easier to accept.  
+* New code should follow the tidyverse [style guide](https://style.tidyverse.org). You can use the [styler](https://CRAN.R-project.org/package=styler) package to apply these styles, but please don't restyle code that has nothing to do with your PR. 
+* We use [roxygen2](https://cran.r-project.org/package=roxygen2) for documentation.
+* We use [testthat](https://cran.r-project.org/package=testthat) for unit tests. Contributions with test cases included are easier to accept. 
 
 ## Code of Conduct
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,14 +1,10 @@
-# For help debugging build failures open an issue on the RStudio community with the 'github-actions' tag.
-# https://community.rstudio.com/new-topic?category=Package%20development&tags=github-actions
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches:
-      - main
-      - master
+    branches: [main, master]
   pull_request:
-    branches:
-      - main
-      - master
+    branches: [main, master]
 
 name: R-CMD-check
 
@@ -22,64 +18,32 @@ jobs:
       fail-fast: false
       matrix:
         config:
+          - {os: macos-latest,   r: 'release'}
           - {os: windows-latest, r: 'release'}
-          - {os: macOS-latest, r: 'release'}
-          - {os: ubuntu-20.04, r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
-          - {os: ubuntu-20.04,   r: 'devel', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest", http-user-agent: "R/4.1.0 (ubuntu-20.04) R (4.1.0 x86_64-pc-linux-gnu x86_64 linux-gnu) on GitHub Actions" }
+          - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
+          - {os: ubuntu-latest,   r: 'release'}
+          - {os: ubuntu-latest,   r: 'oldrel-1'}
 
     env:
-      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
-      RSPM: ${{ matrix.config.rspm }}
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
 
-      - uses: r-lib/actions/setup-pandoc@v1
-
-      - name: Query dependencies
-        run: |
-          install.packages('remotes')
-          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
-          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
-        shell: Rscript {0}
-
-      - name: Restore R package cache
-        uses: actions/cache@v2
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
-          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+          extra-packages: any::rcmdcheck
+          needs: check
 
-      - name: Install system dependencies
-        if: runner.os == 'Linux'
-        run: |
-          while read -r cmd
-          do
-            eval sudo $cmd
-          done < <(Rscript -e 'writeLines(remotes::system_requirements("ubuntu", "20.04"))')
-
-      - name: Install dependencies
-        run: |
-          remotes::install_deps(dependencies = TRUE)
-          remotes::install_cran("rcmdcheck")
-        shell: Rscript {0}
-
-      - name: Check
-        env:
-          _R_CHECK_CRAN_INCOMING_REMOTE_: false
-        run: |
-          options(crayon.enabled = TRUE)
-          rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), error_on = "warning", check_dir = "check")
-        shell: Rscript {0}
-
-      - name: Upload check results
-        if: failure()
-        uses: actions/upload-artifact@main
+      - uses: r-lib/actions/check-r-package@v2
         with:
-          name: ${{ runner.os }}-r${{ matrix.config.r }}-results
-          path: check
+          upload-snapshots: true

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,50 +1,48 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches:
-      - main
-      - master
-    tags:
-      -'*'
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  release:
+    types: [published]
+  workflow_dispatch:
 
 name: pkgdown
 
 jobs:
   pkgdown:
-    runs-on: macOS-latest
+    runs-on: ubuntu-latest
+    # Only restrict concurrency for non-PR jobs
+    concurrency:
+      group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-pandoc@v2
 
-      - uses: r-lib/actions/setup-pandoc@v1
-
-      - name: Query dependencies
-        run: |
-          install.packages('remotes')
-          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
-          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
-        shell: Rscript {0}
-
-      - name: Restore R package cache
-        uses: actions/cache@v2
+      - uses: r-lib/actions/setup-r@v2
         with:
-          path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
-          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+          use-public-rspm: true
 
-      - name: Install dependencies
-        run: |
-          remotes::install_deps(dependencies = TRUE)
-          install.packages("pkgdown", type = "binary")
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::pkgdown, local::.
+          needs: website
+
+      - name: Build site
+        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
         shell: Rscript {0}
 
-      - name: Install package
-        run: R CMD INSTALL .
-
-      - name: Deploy package
-        run: |
-          git config --local user.email "actions@github.com"
-          git config --local user.name "GitHub Actions"
-          Rscript -e 'pkgdown::deploy_to_branch(new_process = FALSE)'
+      - name: Deploy to GitHub pages 🚀
+        if: github.event_name != 'pull_request'
+        uses: JamesIves/github-pages-deploy-action@v4.4.1
+        with:
+          clean: false
+          branch: gh-pages
+          folder: docs

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -1,48 +1,50 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches:
-      - main
-      - master
+    branches: [main, master]
   pull_request:
-    branches:
-      - main
-      - master
+    branches: [main, master]
 
 name: test-coverage
 
 jobs:
   test-coverage:
-    runs-on: macOS-latest
+    runs-on: ubuntu-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: r-lib/actions/setup-r@v1
-
-      - uses: r-lib/actions/setup-pandoc@v1
-
-      - name: Query dependencies
-        run: |
-          install.packages('remotes')
-          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
-          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
-        shell: Rscript {0}
-
-      - name: Restore R package cache
-        uses: actions/cache@v2
+      - uses: r-lib/actions/setup-r@v2
         with:
-          path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
-          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+          use-public-rspm: true
 
-      - name: Install dependencies
-        run: |
-          install.packages(c("remotes"))
-          remotes::install_deps(dependencies = TRUE)
-          remotes::install_cran("covr")
-        shell: Rscript {0}
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::covr
+          needs: coverage
 
       - name: Test coverage
-        run: covr::codecov()
+        run: |
+          covr::codecov(
+            quiet = FALSE,
+            clean = FALSE,
+            install_path = file.path(Sys.getenv("RUNNER_TEMP"), "package")
+          )
         shell: Rscript {0}
+
+      - name: Show testthat output
+        if: always()
+        run: |
+          ## --------------------------------------------------------------------
+          find ${{ runner.temp }}/package -name 'testthat.Rout*' -exec cat '{}' \; || true
+        shell: bash
+
+      - name: Upload test results
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-test-failures
+          path: ${{ runner.temp }}/package

--- a/README.Rmd
+++ b/README.Rmd
@@ -46,7 +46,13 @@ Install the package [from GitHub](https://github.com/co-analysis/a11ytables) usi
 
 ```{r install, eval=FALSE}
 install.packages("remotes")  # if not already installed
-remotes::install_github("co-analysis/a11ytables", build_vignettes = TRUE)
+
+remotes::install_github(
+  "co-analysis/a11ytables",  # GitHub user/repository
+  dependencies = TRUE,  # install required and suggested packages
+  build_vignettes = TRUE  # generate vignette documentation
+)
+
 library(a11ytables)  # attach package
 ```
 
@@ -77,7 +83,7 @@ The Analysis Function Central Team released [a Python package called 'gptables']
 
 ## Code of Conduct
 
-Please note that the {a11ytables} project is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.html).
+Please note that the {a11ytables} project is released with a [Contributor Code of Conduct](https://co-analysis.github.io/a11ytables/CODE_OF_CONDUCT.html).
 
 ## Copyright and Licensing
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,13 @@ GitHub](https://github.com/co-analysis/a11ytables) using
 
 ``` r
 install.packages("remotes")  # if not already installed
-remotes::install_github("co-analysis/a11ytables", build_vignettes = TRUE)
+
+remotes::install_github(
+  "co-analysis/a11ytables",  # GitHub user/repository
+  dependencies = TRUE,  # install required and suggested packages
+  build_vignettes = TRUE  # generate vignette documentation
+)
+
 library(a11ytables)  # attach package
 ```
 
@@ -84,19 +90,19 @@ for function documentation. For long-form documentation, run
 `browseVignettes("a11ytables")` or [visit the package
 website](https://co-analysis.github.io/a11ytables/) to read the:
 
--   [introductory
-    vignette](https://co-analysis.github.io/a11ytables/articles/a11ytables.html)
-    to get started
--   [accessbility checklist
-    vignette](https://co-analysis.github.io/a11ytables/articles/checklist.html)
-    to see how the package complies with best-practice guidance
--   [terminology
-    vignette](https://co-analysis.github.io/a11ytables/articles/terminology)
-    to understand the nomenclature of spreadsheet terms as used in this
-    package
--   [package structure
-    vignette](https://co-analysis.github.io/a11ytables/articles/structure)
-    to see how the package works under the hood
+- [introductory
+  vignette](https://co-analysis.github.io/a11ytables/articles/a11ytables.html)
+  to get started
+- [accessbility checklist
+  vignette](https://co-analysis.github.io/a11ytables/articles/checklist.html)
+  to see how the package complies with best-practice guidance
+- [terminology
+  vignette](https://co-analysis.github.io/a11ytables/articles/terminology)
+  to understand the nomenclature of spreadsheet terms as used in this
+  package
+- [package structure
+  vignette](https://co-analysis.github.io/a11ytables/articles/structure)
+  to see how the package works under the hood
 
 This package also includes [an RStudio
 Addin](https://rstudio.github.io/rstudioaddins/) that inserts pre-filled
@@ -122,7 +128,8 @@ by automating the generation of compliant spreadsheets for publication.
 ## Code of Conduct
 
 Please note that the {a11ytables} project is released with a
-[Contributor Code of Conduct](CODE_OF_CONDUCT.html).
+[Contributor Code of
+Conduct](https://co-analysis.github.io/a11ytables/CODE_OF_CONDUCT.html).
 
 ## Copyright and Licensing
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -16,7 +16,7 @@ footer:
     left: legal
     right: built_with
   components:
-    legal: © Crown Copyright, 2002, Cabinet Office
+    legal: © Crown Copyright, 2022, Cabinet Office
 
 reference:
 - title: "a11ytables"


### PR DESCRIPTION
* Update GitHub Actions yaml files for {pkgdown}, tests and R-CMD check, as per [r-lib examples](https://github.com/r-lib/actions/blob/v2-branch/examples/pkgdown.yaml)
* Set the Code of Conduct link in the README to the {pkgdown} site, rather than an internal reference (close #98, thanks @jtrim-ons)
* Set `dependencies = TRUE` in `install_github()` in the README, which installs suggested packages and will allow the vignettes to build (#99, thanks @jtrim-ons)