### PR TITLE
Correct README spelling

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: a11ytables
 Title: Create Spreadsheet Publications Following Best Practice
-Version: 0.2.0
+Version: 0.2.0.9001
 Authors@R: c(
     person(given = "Crown Copyright", role = c("cph", "fnd")),
     person(given = "Matt", family = "Dray", role = c("aut", "cre"), email = "mwdray@gmail.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# a11ytables 0.2.0.9001
+
+* Hotfix: correct spelling error in installation instructions in README (#111).
+
 # a11ytables 0.2.0
 
 ## New features

--- a/README.Rmd
+++ b/README.Rmd
@@ -56,7 +56,7 @@ remotes::install_github(
 library(a11ytables)  # attach package
 ```
 
-If you need an earlier version of the package, you should replace the `repo` argument call with, for example, `"co-analysis/allytables@v0.1.0"` for the version 0.1.0 release.
+If you need an earlier version of the package, you should replace the `repo` argument call with, for example, `"co-analysis/a11ytables@v0.1.0"` for the version 0.1.0 release.
 
 The package depends on [{openxlsx}](https://ycphs.github.io/openxlsx/) and [{pillar}](https://pillar.r-lib.org/), which are also installed with {a11ytables}.
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ library(a11ytables)  # attach package
 
 If you need an earlier version of the package, you should replace the
 `repo` argument call with, for example,
-`"co-analysis/allytables@v0.1.0"` for the version 0.1.0 release.
+`"co-analysis/a11ytables@v0.1.0"` for the version 0.1.0 release.
 
 The package depends on [{openxlsx}](https://ycphs.github.io/openxlsx/)
 and [{pillar}](https://pillar.r-lib.org/), which are also installed with


### PR DESCRIPTION
Hotfix in case users need to revert to v0.1.0 from 0.2.0, especially given #110. Closes #111.