### PR TITLE
Force error if tab title starts with a numeral

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: a11ytables
 Title: Create Spreadsheet Publications Following Best Practice
-Version: 0.3.0.9001
+Version: 0.3.1
 Authors@R: c(
     person(given = "Matt", family = "Dray", role = c("aut", "cre"), email = "mwdray@gmail.com"),
     person(given = "Tim", family = "Taylor", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
-# a11ytables 0.3.0.9001
+# a11ytables 0.3.1
 
+* Bug fix: make it an error if tab names are started with a numeric value (#124).
 * Reduce gif file size, include additional frame (#121).
 
 # a11ytables 0.3.0

--- a/R/a11ytable.R
+++ b/R/a11ytable.R
@@ -8,9 +8,9 @@
 #'
 #' @param tab_titles Required character vector, one value per sheet. Each title
 #'     will appear literally on each tab of the final spreadsheet output. Keep
-#'     brief. Letters and numbers only; use underscores for spaces. For example:
-#'     'Cover', 'Contents', 'Notes', 'Table_1'. Will be corrected automatically
-#'     if non-conforming.
+#'     brief. Letters and numbers only; do not start with a number; use
+#'     underscores for spaces. For example: 'Cover', 'Contents', 'Notes',
+#'     'Table_1'. Will be corrected automatically unless there's an error.
 #' @param sheet_types Required character vector, one value per sheet. Sheets
 #'     that don't contain publication tables ('meta' sheets) should be of type
 #'     'contents', 'cover' or 'notes'. Sheets that contain statistical tables of
@@ -210,6 +210,7 @@ create_a11ytable <- function(
 as_a11ytable <- function(x) {
 
   if (any(names(x) %in% "tab_title")) {
+    .check_tab_titles(x[["tab_title"]])
     x[["tab_title"]] <- .clean_tab_titles(x[["tab_title"]])
   }
 

--- a/R/utils-a11ytable.R
+++ b/R/utils-a11ytable.R
@@ -1,3 +1,19 @@
+#' Clean Sheet Tab Titles
+#' @param tab_titles Character vector. Names of tabs in the workbook.
+#' @noRd
+.check_tab_titles <- function(tab_titles) {
+
+  tab_title_num_start <- grep("^\\d", unlist(tab_titles))
+
+  if (length(tab_title_num_start) > 0) {
+    stop(
+      "Elements in tab_titles must not begin with a numeral (change ",
+      .vector_to_sentence(tab_titles[tab_title_num_start]), ").",
+      call. = FALSE
+    )
+  }
+
+}
 
 #' Clean Sheet Tab Titles
 #' @param tab_titles Character vector. Names of tabs in the workbook.

--- a/man/create_a11ytable.Rd
+++ b/man/create_a11ytable.Rd
@@ -17,9 +17,9 @@ create_a11ytable(
 \arguments{
 \item{tab_titles}{Required character vector, one value per sheet. Each title
 will appear literally on each tab of the final spreadsheet output. Keep
-brief. Letters and numbers only; use underscores for spaces. For example:
-'Cover', 'Contents', 'Notes', 'Table_1'. Will be corrected automatically
-if non-conforming.}
+brief. Letters and numbers only; do not start with a number; use
+underscores for spaces. For example: 'Cover', 'Contents', 'Notes',
+'Table_1'. Will be corrected automatically unless there's an error.}
 
 \item{sheet_types}{Required character vector, one value per sheet. Sheets
 that don't contain publication tables ('meta' sheets) should be of type

--- a/vignettes/a11ytables.Rmd
+++ b/vignettes/a11ytables.Rmd
@@ -190,7 +190,7 @@ my_a11ytable <-
   )
 ```
 
-The function will return errors or warnings if anything is missing or seems odd. For example, we were warned that a value we supplied to `tab_title` had to be cleaned from 'Table 1' to 'Table_1', since blank spaces are not allowed in tab names.
+The function will return errors or warnings if anything is missing or seems odd. For example, we were warned that a value we supplied to `tab_title` had to be cleaned from 'Table 1' to 'Table_1', since blank spaces are not allowed in tab names. Note that there will be an error if there are any tab titles that start with a numeral.
 
 Here's a preview of the object that was created:
 


### PR DESCRIPTION
Closes #124.

Doesn't solve the underlying problem, but prevents it from happening. Error preferred to warning because I don't think there's a good autocorrection (putting an underscore at the start probably isn't helpful). Added some tests and noted in function docs and vignette.