### PR TITLE
Convert factor columns to character before checking max character length

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,7 @@ Authors@R: c(
   )
 Description: Generate spreadsheet publications that follow best practice
     guidance from the UK government's Analysis Function, with a focus on
-    accessibility. Based on {openxlsx}. See also the Python package
+    accessibility. Based on 'openxlsx'. See also the Python package
     'gptables'.
 License: MIT + file LICENSE
 URL: https://co-analysis.github.io/a11ytables/,
@@ -33,4 +33,4 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,22 +1,20 @@
 Package: a11ytables
 Title: Create Spreadsheet Publications Following Best Practice
-Version: 0.3.1
+Version: 0.3.2
 Authors@R: c(
-    person(given = "Matt", family = "Dray", role = c("aut", "cre"), email = "mwdray@gmail.com"),
-    person(given = "Tim", family = "Taylor", role = "ctb"),
-    person(given = "Matt", family = "Kerlogue", role = "ctb"),
-    person(given = "Crown Copyright", role = c("cph", "fnd"))
-    )
+    person("Matt", "Dray", , "mwdray@gmail.com", role = c("aut", "cre")),
+    person("Tim", "Taylor", role = "ctb"),
+    person("Matt", "Kerlogue", role = "ctb"),
+    person("Crown Copyright", role = c("cph", "fnd"))
+  )
 Description: Generate spreadsheet publications that follow best practice
     guidance from the UK government's Analysis Function, with a focus on
-    accessibility. Based on {openxlsx}. See also the Python package 'gptables'.
-URL: https://co-analysis.github.io/a11ytables/, https://github.com/co-analysis/a11ytables
-BugReports: https://github.com/co-analysis/a11ytables/issues
+    accessibility. Based on {openxlsx}. See also the Python package
+    'gptables'.
 License: MIT + file LICENSE
-Encoding: UTF-8
-LazyData: true
-Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+URL: https://co-analysis.github.io/a11ytables/,
+    https://github.com/co-analysis/a11ytables
+BugReports: https://github.com/co-analysis/a11ytables/issues
 Depends: 
     R (>= 2.10)
 Imports: 
@@ -29,5 +27,10 @@ Suggests:
     rstudioapi,
     testthat (>= 3.0.0),
     tibble
+VignetteBuilder: 
+    knitr
 Config/testthat/edition: 3
-VignetteBuilder: knitr
+Encoding: UTF-8
+LazyData: true
+Roxygen: list(markdown = TRUE)
+RoxygenNote: 7.2.3

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,11 @@
+# a11ytables 0.3.2
+
+* Bug fix: ensured factors are converted to character before assessing the need for a column-header linebreak with `nchar()` (a function that doesn't accept factors) (#110).
+
 # a11ytables 0.3.1
 
-* Bug fix: make it an error if tab names are started with a numeric value (#124).
-* Reduce gif file size, include additional frame (#121).
+* Bug fix: made it an error if tab names are started with a numeric value (#124).
+* Reduced gif file size, include additional frame (#121).
 
 # a11ytables 0.3.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # a11ytables 0.3.2
 
-* Bug fix: ensured factors are converted to character before assessing the need for a column-header linebreak with `nchar()` (a function that doesn't accept factors) (#110).
+* Bug fix: ensured factors are converted to character before assessing whether the column needs to be widened (#110, #113).
 
 # a11ytables 0.3.1
 

--- a/R/utils-workbook-style.R
+++ b/R/utils-workbook-style.R
@@ -94,7 +94,9 @@
   likely_num_cols <- names(Filter(isTRUE, cols_numeric))  # return names of columns that are most likely numeric
   num_cols_index <- which(names(table) %in% likely_num_cols)  # get the index of columns that are likely numeric, so styles can be applied
 
-  # Columns that should be wider than default
+  # Find indices of columns that should be wider than default
+  is_factor_column <- sapply(table, is.factor)   # nchar (below) fails on factors
+  table[is_factor_column] <- lapply(table[is_factor_column], as.character)
   wide_cells <- names(Filter(function(x) max(nchar(x)) > nchar_break, table))
   wide_cells_index <- which(names(table) %in% wide_cells)
   wide_headers_index <- which(nchar(names(table)) > nchar_break)

--- a/man/a11ytables-package.Rd
+++ b/man/a11ytables-package.Rd
@@ -8,7 +8,7 @@
 \description{
 \if{html}{\figure{logo.png}{options: style='float: right' alt='logo' width='120'}}
 
-Generate spreadsheet publications that follow best practice guidance from the UK government's Analysis Function, with a focus on accessibility. Based on {openxlsx}. See also the Python package 'gptables'.
+Generate spreadsheet publications that follow best practice guidance from the UK government's Analysis Function, with a focus on accessibility. Based on 'openxlsx'. See also the Python package 'gptables'.
 }
 \seealso{
 Useful links:


### PR DESCRIPTION
Close #110.

* Coerce factor columns to character before using `nchar()` to decide whether columns should be widened.
* Bump version number in DESCRIPTION and NEWS.
* Use tidy DESCRIPTION.