### PR TITLE
Faster table styling

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * Added number_formatter function for control over how numbers appear.
 * Bug fix: re-enabled RStudio Addin to insert code for {aftables} workflow (#151).
+* Bug fix: generate_workbook now runs quicker for spreadsheets with large tables.
 
 # aftables 2.0.1
 

--- a/R/utils-workbook.R
+++ b/R/utils-workbook.R
@@ -926,7 +926,6 @@
                                       aftables_decimal_places,
                                       aftables_thousand_separators,
                                       number_cell_references) {
-
   numeric_columns <- colnames(number_cell_references)
 
   decimal_places <- decimal_places |> unlist()
@@ -971,36 +970,35 @@
     tibble::as_tibble_row() |>
     tidyr::uncount(nrow(number_cell_references))
 
-
-  cell_format_options <- tibble(
+  output <- tibble::tibble(
+    cell_reference = as.vector(number_cell_references),
     currency_units = unlist(currency_units, use.names = FALSE),
     decimal_places = unlist(decimal_places, use.names = FALSE),
     thousand_separators = unlist(thousand_separators, use.names = FALSE)
-  )
-
-  output <-
-    tibble::tibble(
-      cell_reference = as.vector(number_cell_references),
-      cell_format = cell_format_options |>
-        mutate(
-          format = paste0(
-            currency_units,
-            ifelse(thousand_separators, "#,##0", "###0"),
-            ifelse(decimal_places > 0, ".", ""),
-            purrr::map_chr(
-              decimal_places,
-              \(x) paste0(rep("0", times = x), collapse = "")
-            )
-          )
-        ) |>
-        dplyr::select(format) |>
-        unlist(use.names = FALSE)
+  ) |>
+    mutate(
+      cell_format = paste0(
+        currency_units,
+        ifelse(thousand_separators, "#,##0", "###0"),
+        ifelse(decimal_places > 0, ".", ""),
+        purrr::map_chr(
+          decimal_places,
+          \(x) paste0(rep("0", times = x), collapse = "")
+        )
+      )
+    ) |>
+    dplyr::select(
+      .data$cell_reference,
+      .data$cell_format
     ) |>
     dplyr::group_by(.data$cell_format) |>
-    mutate(cell_reference = paste0(
-      paste0(.data$cell_reference, collapse = ";"),
-      ";"
-    )) |>
+    mutate(
+      cell_reference =
+        paste0(
+          paste0(.data$cell_reference, collapse = ";"),
+          ";"
+        )
+    ) |>
     dplyr::ungroup() |>
     dplyr::distinct() |>
     as.list()

--- a/R/utils-workbook.R
+++ b/R/utils-workbook.R
@@ -992,7 +992,7 @@
       .data$cell_format
     ) |>
     dplyr::group_by(.data$cell_format) |>
-    mutate(
+    dplyr::summarise(
       cell_reference =
         paste0(
           paste0(.data$cell_reference, collapse = ";"),
@@ -1000,7 +1000,6 @@
         )
     ) |>
     dplyr::ungroup() |>
-    dplyr::distinct() |>
     as.list()
 
   output

--- a/R/utils-workbook.R
+++ b/R/utils-workbook.R
@@ -978,23 +978,32 @@
     thousand_separators = unlist(thousand_separators, use.names = FALSE)
   )
 
-  output <- list(
-    cell_reference = as.vector(number_cell_references),
-    cell_format = cell_format_options |>
-      mutate(
-        format = paste0(
-          currency_units,
-          ifelse(thousand_separators, "#,##0", "###0"),
-          ifelse(decimal_places > 0, ".", ""),
-          purrr::map_chr(
-            decimal_places,
-            \(x) paste0(rep("0", times = x), collapse = "")
+  output <-
+    tibble::tibble(
+      cell_reference = as.vector(number_cell_references),
+      cell_format = cell_format_options |>
+        mutate(
+          format = paste0(
+            currency_units,
+            ifelse(thousand_separators, "#,##0", "###0"),
+            ifelse(decimal_places > 0, ".", ""),
+            purrr::map_chr(
+              decimal_places,
+              \(x) paste0(rep("0", times = x), collapse = "")
+            )
           )
-        )
-      ) |>
-      dplyr::select(format) |>
-      unlist(use.names = FALSE)
-  )
+        ) |>
+        dplyr::select(format) |>
+        unlist(use.names = FALSE)
+    ) |>
+    dplyr::group_by(.data$cell_format) |>
+    mutate(cell_reference = paste0(
+      paste0(.data$cell_reference, collapse = ";"),
+      ";"
+    )) |>
+    dplyr::ungroup() |>
+    dplyr::distinct() |>
+    as.list()
 
   output
 }

--- a/vignettes/aftables.Rmd
+++ b/vignettes/aftables.Rmd
@@ -145,7 +145,7 @@ The default behaviour of aftables is to format numbers with thousand separators,
 The number_formatter function can be used to override aftables' default behaviour and specify if thousand separators should be used, and how many decimal places should be displayed. This code changes the number of decimal places for the `Numeric decimal` column from 5 (by default) to 2, and removes thousand separators for the `Numeric thousands` column:
 
 ```{r results=FALSE}
-table_1_df <- table_1_df |> 
+table_1_df <- table_1_df |>
   aftables::number_formatter(
     columns = "Numeric decimal",
     decimal_places = 2


### PR DESCRIPTION
…mat separated by semicolons, to reduce number of calls to add_numfmt function to one per number format.

Remove lint from aftables.Rmd.